### PR TITLE
Fix composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"guzzlehttp/guzzle": "4.2.*",
-		"symfony/console": "2.6.*"
+		"symfony/console": "~2.6.*"
 	},
 	"bin": [
 		"craft"


### PR DESCRIPTION
Tried following the instructions and after running `composer global require "themccallister/craft=dev-master` I get the following:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for themccallister/craft dev-master -> satisfiable by themccallister/craft[dev-master].
    - Conclusion: remove symfony/console v2.7.1
    - Conclusion: don't install symfony/console v2.7.1
    - themccallister/craft dev-master requires symfony/console 2.6.* -> satisfiable by symfony/console[v2.6.0, v2.6.1, v2.6.10, v2.6.11, v2.6.2, v2.6.3, v2.6.4, v2.6.5, v2.6.6, v2.6.7, v2.6.8, v2.6.9].
    - Can only install one of: symfony/console[v2.6.0, v2.7.1].
    - Can only install one of: symfony/console[v2.6.1, v2.7.1].
    - Can only install one of: symfony/console[v2.6.10, v2.7.1].
    - Can only install one of: symfony/console[v2.6.11, v2.7.1].
    - Can only install one of: symfony/console[v2.6.2, v2.7.1].
    - Can only install one of: symfony/console[v2.6.3, v2.7.1].
    - Can only install one of: symfony/console[v2.6.4, v2.7.1].
    - Can only install one of: symfony/console[v2.6.5, v2.7.1].
    - Can only install one of: symfony/console[v2.6.6, v2.7.1].
    - Can only install one of: symfony/console[v2.6.7, v2.7.1].
    - Can only install one of: symfony/console[v2.6.8, v2.7.1].
    - Can only install one of: symfony/console[v2.6.9, v2.7.1].
    - Installation request for symfony/console == 2.7.1.0 -> satisfiable by symfony/console[v2.7.1].


Installation failed, reverting ./composer.json to its original content.
```

So have changed to allow composer to use later versions of `symfony/console`.